### PR TITLE
Remove Docling from Markdown conversion

### DIFF
--- a/sharepoint/.env.example
+++ b/sharepoint/.env.example
@@ -2,8 +2,6 @@
 SHAREPOINT_TENANT_ID=your-tenant-id
 SHAREPOINT_CLIENT_ID=your-application-client-id
 SHAREPOINT_CLIENT_SECRET=your-client-secret-value
-# The Secret ID from the Azure portal (for reference / rotation tracking)
-SHAREPOINT_CLIENT_SECRET_ID=your-client-secret-id
 
 # SharePoint target
 # Full URL of the SharePoint site

--- a/sharepoint/Dockerfile
+++ b/sharepoint/Dockerfile
@@ -18,6 +18,7 @@ COPY sharepoint/main.py .
 COPY sharepoint/pipeline_runner.py .
 COPY sharepoint/sharepoint_client.py .
 COPY sharepoint/sharepoint_crawler.py .
+COPY sharepoint/requirements.txt .
 
 # Copy Open WebUI importer as the module name used by pipeline_runner.py
 COPY scripts/import_files_and_external_links.py owui_importer.py

--- a/sharepoint/README.md
+++ b/sharepoint/README.md
@@ -72,15 +72,12 @@ python main.py --list
 
 # Use a custom config file
 python main.py --config /path/to/my_config.yaml
-
-# Define markitdown as converter (default is docling)
-python main.py --converter markitdown
 ```
 
 The script will:
 1. Authenticate against Azure AD using client credentials (app-only).
 2. Crawl all SharePoint pages and supported files from the selected sites.
-3. Convert content to Markdown using [docling](https://github.com/DS4SD/docling).
+3. Convert content to Markdown using [MarkItDown](https://github.com/microsoft/markitdown).
 4. Save results under `output/<site-name>/`:
    - `output/<site-name>/pages/` — site pages as `.md` files
    - `output/<site-name>/files/` — converted documents as `.md` + `.json` metadata files

--- a/sharepoint/content_processor.py
+++ b/sharepoint/content_processor.py
@@ -3,7 +3,7 @@ HTML-to-Markdown converter for SharePoint page content.
 
 SharePoint pages arrive as raw HTML strings (web part ``innerHtml`` fragments
 assembled by :meth:`~sharepoint_client.SharePointClient.get_page_content_html`).
-This module converts those strings to structured Markdown using docling's
+This module converts those strings to structured Markdown using MarkItDown's
 HTML pipeline, producing output consistent with what the file crawler
 generates for DOCX/PDF/PPTX documents.
 """
@@ -14,33 +14,29 @@ import logging
 import tempfile
 import os
 
-from docling.document_converter import DocumentConverter, InputFormat
-from docling.document_converter import ConversionResult
+from markitdown import MarkItDown
 
 logger = logging.getLogger(__name__)
 
 
 class HtmlToMarkdownConverter:
-    """Converts raw HTML strings to Markdown using docling's HTML pipeline.
+    """Converts raw HTML strings to Markdown using MarkItDown.
 
     Intended for SharePoint site-page content where the Graph API returns
     HTML fragments rather than downloadable files.  For binary files (PDF,
     DOCX, etc.) use :class:`~sharepoint_crawler.SharePointCrawler` directly.
 
-    A single :class:`~docling.document_converter.DocumentConverter` instance
-    is reused across calls to avoid repeated model-loading overhead.
+    A single :class:`~markitdown.MarkItDown` instance is reused across calls
+    to avoid repeated initialisation overhead.
     """
 
     def __init__(self) -> None:
-        # Initialise once — converter setup can be expensive
-        self._converter = DocumentConverter(
-            allowed_formats=[InputFormat.HTML],
-        )
+        self._converter = MarkItDown()
 
     def convert(self, html: str, source_label: str = "page") -> str:
         """Convert an HTML string to Markdown.
 
-        Docling requires a file path as input, so the HTML is written to a
+        MarkItDown requires a file path as input, so the HTML is written to a
         temporary file, converted, and the file is deleted afterwards.
 
         Args:
@@ -49,14 +45,13 @@ class HtmlToMarkdownConverter:
                 identify which page or source is being processed.
 
         Returns:
-            Markdown string produced by docling, or an empty string if the
+            Markdown string produced by MarkItDown, or an empty string if the
             input is blank or conversion fails.
         """
         if not html or not html.strip():
             logger.warning("Empty HTML received for '%s', skipping.", source_label)
             return ""
 
-        # Write to a temp file — docling requires a file path, not a string
         with tempfile.NamedTemporaryFile(
             suffix=".html", mode="w", encoding="utf-8", delete=False
         ) as tmp:
@@ -64,14 +59,14 @@ class HtmlToMarkdownConverter:
             tmp_path = tmp.name
 
         try:
-            result: ConversionResult = self._converter.convert(tmp_path)
-            markdown = result.document.export_to_markdown()
+            result = self._converter.convert(tmp_path)
+            markdown = result.text_content or ""
             logger.debug(
                 "Converted '%s': %d chars of Markdown.", source_label, len(markdown)
             )
             return markdown
         except Exception as exc:
-            logger.error("docling conversion failed for '%s': %s", source_label, exc)
+            logger.error("MarkItDown conversion failed for '%s': %s", source_label, exc)
             return ""
         finally:
             os.unlink(tmp_path)

--- a/sharepoint/document_converter.py
+++ b/sharepoint/document_converter.py
@@ -1,13 +1,13 @@
 """
 Document converter abstractions for SharePoint file processing.
 
-Provides a pluggable conversion layer so the crawler can use either
-docling or MarkItDown as its backend, while sharing common post-processing
-logic (NaN / artefact cleanup) defined in :class:`BaseDocumentConverter`.
+Provides a conversion layer using MarkItDown as the backend, with shared
+post-processing logic (NaN / artefact cleanup) defined in
+:class:`BaseDocumentConverter`.
 
 Usage::
 
-    converter = MarkItDownDocumentConverter()  # or DoclingDocumentConverter()
+    converter = MarkItDownDocumentConverter()
     markdown = converter.convert_bytes(raw_bytes, "report.xlsx")
 """
 
@@ -130,31 +130,6 @@ class BaseDocumentConverter(abc.ABC):
             else:
                 result.append(line)
         return "".join(result)
-
-
-# ---------------------------------------------------------------------------
-# Docling backend
-# ---------------------------------------------------------------------------
-
-class DoclingDocumentConverter(BaseDocumentConverter):
-    """Converts files to Markdown using `docling <https://github.com/DS4SD/docling>`_.
-
-    This is the original backend and supports PDF, DOCX, PPTX and XLSX.
-    """
-
-    def __init__(self) -> None:
-        from docling.document_converter import DocumentConverter
-        self._converter = DocumentConverter()
-
-    def _convert_bytes_impl(self, raw: bytes, filename: str) -> str | None:
-        try:
-            from docling.datamodel.base_models import DocumentStream
-            stream = DocumentStream(name=filename, stream=io.BytesIO(raw))
-            result = self._converter.convert(stream)
-            return result.document.export_to_markdown()
-        except Exception:
-            logger.exception("docling failed to convert '%s'.", filename)
-            return None
 
 
 # ---------------------------------------------------------------------------

--- a/sharepoint/main.py
+++ b/sharepoint/main.py
@@ -27,7 +27,7 @@ from dotenv import load_dotenv
 from config_loader import load_config, list_available_sites, SiteConfig
 from sharepoint_client import SharePointClient
 from sharepoint_crawler import SharePointCrawler
-from document_converter import BaseDocumentConverter, DoclingDocumentConverter, MarkItDownDocumentConverter
+from document_converter import BaseDocumentConverter, MarkItDownDocumentConverter
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -99,12 +99,6 @@ def main() -> None:
         help="List configured sites and exit.",
     )
     parser.add_argument(
-        "--converter",
-        choices=["docling", "markitdown"],
-        default="docling",
-        help="Document converter backend to use (default: docling).",
-    )
-    parser.add_argument(
         "--config",
         type=Path,
         default=None,
@@ -133,13 +127,8 @@ def main() -> None:
     logger.info("Will crawl %d site(s)", len(sites))
 
     # Instantiate converter backend
-    converter: BaseDocumentConverter
-    if args.converter == "markitdown":
-        logger.info("Using MarkItDown converter backend.")
-        converter = MarkItDownDocumentConverter()
-    else:
-        logger.info("Using Docling converter backend.")
-        converter = DoclingDocumentConverter()
+    logger.info("Using MarkItDown converter backend.")
+    converter: BaseDocumentConverter = MarkItDownDocumentConverter()
 
     # Crawl each site
     total_results = {"pages": 0, "files": 0}

--- a/sharepoint/requirements.txt
+++ b/sharepoint/requirements.txt
@@ -1,7 +1,6 @@
 msal>=1.31.0
 requests>=2.32.0
 python-dotenv>=1.0.0
-docling>=2.0.0
 httpx>=0.28.0
 pyyaml>=6.0
 markitdown[all]>=0.1.0

--- a/sharepoint/sharepoint_crawler.py
+++ b/sharepoint/sharepoint_crawler.py
@@ -2,10 +2,8 @@
 SharePoint crawler: fetches all pages and files from a SharePoint site
 and converts them to Markdown documents.
 
-File conversion is delegated to a pluggable :class:`BaseDocumentConverter`
-(see ``document_converter.py``).  Pass ``converter=`` to the constructor to
-switch between :class:`DoclingDocumentConverter` (default) and
-:class:`MarkItDownDocumentConverter`.
+File conversion is delegated to :class:`MarkItDownDocumentConverter`
+(see ``document_converter.py``).
 """
 
 from __future__ import annotations
@@ -18,7 +16,7 @@ from pathlib import Path
 
 from sharepoint_client import SharePointClient
 from content_processor import HtmlToMarkdownConverter
-from document_converter import BaseDocumentConverter, DoclingDocumentConverter
+from document_converter import BaseDocumentConverter, MarkItDownDocumentConverter
 
 logger = logging.getLogger(__name__)
 
@@ -71,16 +69,14 @@ class SharePointCrawler:
             page_paths: Optional list of page paths to filter. If provided, only
                 pages matching these paths will be crawled. Omit to crawl all pages.
             converter: Document converter backend to use for binary files.
-                Defaults to :class:`~document_converter.DoclingDocumentConverter`.
-                Pass a :class:`~document_converter.MarkItDownDocumentConverter`
-                instance to use MarkItDown instead.
+                Defaults to :class:`~document_converter.MarkItDownDocumentConverter`.
         """
         self.client = client
         self.output_dir = Path(output_dir)
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.file_extensions = file_extensions if file_extensions is not None else SUPPORTED_FILE_EXTENSIONS
         self.page_paths = page_paths
-        self._converter: BaseDocumentConverter = converter or DoclingDocumentConverter()
+        self._converter: BaseDocumentConverter = converter or MarkItDownDocumentConverter()
         self._html_converter = HtmlToMarkdownConverter()
 
     # ------------------------------------------------------------------
@@ -148,7 +144,7 @@ class SharePointCrawler:
                 logger.warning("Empty content for page '%s', skipping.", title)
                 continue
 
-            # Convert HTML to Markdown via docling
+            # Convert HTML to Markdown via MarkItDown
             text = self._html_converter.convert(html, source_label=title)
             if not text:
                 logger.warning("Markdown conversion produced no output for page '%s', skipping.", title)
@@ -223,7 +219,7 @@ class SharePointCrawler:
                 logger.exception("Failed to download '%s'.", name)
                 continue
 
-            # Convert to Markdown via docling
+            # Convert to Markdown via MarkItDown
             markdown = self._convert_file(raw, name)
             if not markdown:
                 continue


### PR DESCRIPTION
Here's removed Docling from Markdown conversion, using Markitdown by default instead. There was an issue with Docling causing unnecessary whitespaces in converted files.
Also added missing copy statement to Dockerfile and removed unnecessary env parameter for example file.